### PR TITLE
Add exporter on new testnet

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -634,7 +634,7 @@ func (lb *LinoBlockchain) ExportAppStateAndValidators() (appState json.RawMessag
 			panic("failed to create account")
 		}
 		defer f.Close()
-		n, err := lb.cdc.MarshalBinaryWriter(f, exporter(ctx))
+		n, err := lb.cdc.MarshalBinaryLengthPrefixedWriter(f, exporter(ctx))
 		if err != nil {
 			panic("failed to marshal binary for " + filename + " due to " + err.Error())
 		}

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -30,6 +30,7 @@ type GenesisState struct {
 	Infra          []GenesisInfraProvider    `json:"infra"`
 	GenesisParam   GenesisParam              `json:"genesis_param"`
 	InitGlobalMeta globalModel.InitParamList `json:"init_global_meta"`
+	Reputation     []byte                    `json:"reputation"`
 }
 
 // genesis account will get coin to the address and register user

--- a/exporter/appstate.go
+++ b/exporter/appstate.go
@@ -1,0 +1,30 @@
+package exporter
+
+// AppState contains all informations that needs to migrate when blockchain upgrade.
+type AppState struct {
+	// Accounts            []AccountRow     `json:"accounts"`
+	// AccountGrantPubKeys []GrantPubKeyRow `json:"account_grant_pub_keys"`
+
+	// Developers           []Developer
+	// DeveloperList        DeveloperList
+
+	// GlobalTimeEventLists []GlobalTimeEventList
+	// GlobalStakeStats     []GlobalStakeStat
+	// GlobalMisc           GlobalMisc
+
+	// InfraProviders       []InfraProvider
+	// InfraProviderList    InfraProviderList
+
+	// Posts                []Post
+	// PostUsers            []PostUser
+	// PostComments         []PostComment
+
+	// proposal is skipped
+	// vote is skipped
+
+	// Validators    []Validator
+	// ValidatorList ValidatorList
+
+	// reputaion has pure math model implementation and can be simply marshal to bytes out.
+	// reputation []byte
+}

--- a/x/account/manager.go
+++ b/x/account/manager.go
@@ -1100,6 +1100,11 @@ func (accManager AccountManager) cleanExpiredFrozenMoney(ctx sdk.Context, bank *
 }
 
 // IterateAccounts - iterate accounts in KVStore
+func (accManager AccountManager) Export(ctx sdk.Context) *model.AccountTables {
+	return accManager.storage.Export(ctx)
+}
+
+// IterateAccounts - iterate accounts in KVStore
 func (accManager AccountManager) IterateAccounts(ctx sdk.Context, process func(model.AccountInfo, model.AccountBank) (stop bool)) {
 	accManager.storage.IterateAccounts(ctx, process)
 }

--- a/x/account/model/account.go
+++ b/x/account/model/account.go
@@ -46,7 +46,7 @@ type PendingCoinDayQueue struct {
 func (p PendingCoinDayQueue) ToIR() PendingCoinDayQueueIR {
 	return PendingCoinDayQueueIR{
 		LastUpdatedAt:   p.LastUpdatedAt,
-		TotalCoinDay:    p.TotalCoinDay.FloatString(),
+		TotalCoinDay:    p.TotalCoinDay.String(),
 		TotalCoin:       p.TotalCoin,
 		PendingCoinDays: p.PendingCoinDays,
 	}

--- a/x/account/model/account.go
+++ b/x/account/model/account.go
@@ -42,6 +42,16 @@ type PendingCoinDayQueue struct {
 	PendingCoinDays []PendingCoinDay `json:"pending_coin_days"`
 }
 
+// ToIR coin.
+func (p PendingCoinDayQueue) ToIR() PendingCoinDayQueueIR {
+	return PendingCoinDayQueueIR{
+		LastUpdatedAt:   p.LastUpdatedAt,
+		TotalCoinDay:    p.TotalCoinDay.FloatString(),
+		TotalCoin:       p.TotalCoin,
+		PendingCoinDays: p.PendingCoinDays,
+	}
+}
+
 // PendingCoinDay - pending coin day in the list
 type PendingCoinDay struct {
 	StartTime int64      `json:"start_time"`

--- a/x/account/model/ir.go
+++ b/x/account/model/ir.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// PendingCoinDayQueueIR - TotalCoinDay: rat -> string
+type PendingCoinDayQueueIR struct {
+	LastUpdatedAt   int64            `json:"last_updated_at"`
+	TotalCoinDay    string           `json:"total_coin_day"`
+	TotalCoin       types.Coin       `json:"total_coin"`
+	PendingCoinDays []PendingCoinDay `json:"pending_coin_days"`
+}
+
+// AccountRowIR account related information when migrate, pk: Username
+type AccountRowIR struct {
+	Username            types.AccountKey      `json:"username"`
+	Info                AccountInfo           `json:"info"`
+	Bank                AccountBank           `json:"bank"`
+	Meta                AccountMeta           `json:"meta"`
+	PendingCoinDayQueue PendingCoinDayQueueIR `json:"pending_coin_day_queue"`
+}
+
+// AccountTablesIR -
+type AccountTablesIR struct {
+	Accounts            []AccountRowIR   `json:"accounts"`
+	AccountGrantPubKeys []GrantPubKeyRow `json:"account_grant_pub_keys"`
+}

--- a/x/account/model/state.go
+++ b/x/account/model/state.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	crypto "github.com/tendermint/tendermint/crypto"
+
+	"github.com/lino-network/lino/types"
+)
+
+// AccountRow account related information when migrate, pk: Username
+type AccountRow struct {
+	Username            types.AccountKey    `json:"username"`
+	Info                AccountInfo         `json:"info"`
+	Bank                AccountBank         `json:"bank"`
+	Meta                AccountMeta         `json:"meta"`
+	PendingCoinDayQueue PendingCoinDayQueue `json:"pending_coin_day_queue"`
+}
+
+// ToIR -
+func (a AccountRow) ToIR() AccountRowIR {
+	return AccountRowIR{
+		Username:            a.Username,
+		Info:                a.Info,
+		Bank:                a.Bank,
+		Meta:                a.Meta,
+		PendingCoinDayQueue: a.PendingCoinDayQueue.ToIR(),
+	}
+}
+
+// GrantPubKeyRow also in account, pk: (Username, pubKey)
+type GrantPubKeyRow struct {
+	Username    types.AccountKey `json:"username"`
+	PubKey      crypto.PubKey    `json:"pub_key"`
+	GrantPubKey GrantPubKey      `json:"grant_pub_key"`
+}
+
+// AccountTables is the state of account storage, organized as a table.
+type AccountTables struct {
+	Accounts            []AccountRow     `json:"accounts"`
+	AccountGrantPubKeys []GrantPubKeyRow `json:"account_grant_pub_keys"`
+}
+
+// ToIR -
+func (a AccountTables) ToIR() *AccountTablesIR {
+	tables := &AccountTablesIR{}
+	for _, v := range a.Accounts {
+		tables.Accounts = append(tables.Accounts, v.ToIR())
+	}
+	tables.AccountGrantPubKeys = a.AccountGrantPubKeys
+	return tables
+}

--- a/x/developer/manager.go
+++ b/x/developer/manager.go
@@ -208,3 +208,8 @@ func (dm DeveloperManager) WithdrawAll(
 	}
 	return developer.Deposit, nil
 }
+
+// Export state of storage
+func (dm DeveloperManager) Export(ctx sdk.Context) *model.DeveloperTables {
+	return dm.storage.Export(ctx)
+}

--- a/x/developer/model/ir.go
+++ b/x/developer/model/ir.go
@@ -1,0 +1,4 @@
+package model
+
+// DeveloperTablesIR -
+type DeveloperTablesIR = DeveloperTables

--- a/x/developer/model/state.go
+++ b/x/developer/model/state.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// DeveloperRow - pk: Username
+type DeveloperRow struct {
+	Username  types.AccountKey `json:"username"`
+	Developer Developer        `json:"developer"`
+}
+
+// DeveloperListTable all developers, pk: none
+type DeveloperListTable struct {
+	List DeveloperList `json:"list"`
+}
+
+// DeveloperTables is the state of developer storage, organized as a table.
+type DeveloperTables struct {
+	Developers    []DeveloperRow     `json:"developers"`
+	DeveloperList DeveloperListTable `json:"developer_list"`
+}
+
+// ToIR -
+func (d DeveloperTables) ToIR() DeveloperTablesIR {
+	return d
+}

--- a/x/global/manager.go
+++ b/x/global/manager.go
@@ -23,6 +23,11 @@ func NewGlobalManager(key sdk.StoreKey, holder param.ParamHolder) GlobalManager 
 	}
 }
 
+// Export state
+func (gm GlobalManager) Export(ctx sdk.Context) *model.GlobalTables {
+	return gm.storage.Export(ctx)
+}
+
 // WireCodec - access to global manager codec
 func (gm GlobalManager) WireCodec() *wire.Codec {
 	return gm.storage.WireCodec()

--- a/x/global/model/global.go
+++ b/x/global/model/global.go
@@ -36,6 +36,14 @@ type TPS struct {
 	MaxTPS     sdk.Dec `json:"max_tps"`
 }
 
+// ToIR -
+func (t *TPS) ToIR() TPSIR {
+	return TPSIR{
+		CurrentTPS: t.CurrentTPS.FloatString(),
+		MaxTPS:     t.MaxTPS.FloatString(),
+	}
+}
+
 // InflationPool, determined by GlobalAllocation
 // InfraInflationPool inflation pool for infra
 // TotalContentCreatorInflationPool total inflation pool for content creator this year
@@ -57,6 +65,16 @@ type ConsumptionMeta struct {
 	ConsumptionWindow            types.Coin `json:"consumption_window"`
 	ConsumptionRewardPool        types.Coin `json:"consumption_reward_pool"`
 	ConsumptionFreezingPeriodSec int64      `json:"consumption_freezing_period_second"`
+}
+
+// ToIR -
+func (c *ConsumptionMeta) ToIR() ConsumptionMetaIR {
+	return ConsumptionMetaIR{
+		ConsumptionFrictionRate:      c.ConsumptionFrictionRate.FloatString(),
+		ConsumptionWindow:            c.ConsumptionWindow,
+		ConsumptionRewardPool:        c.ConsumptionRewardPool,
+		ConsumptionFreezingPeriodSec: c.ConsumptionFreezingPeriodSec,
+	}
 }
 
 // InitParamList - genesis parameters

--- a/x/global/model/global.go
+++ b/x/global/model/global.go
@@ -39,8 +39,8 @@ type TPS struct {
 // ToIR -
 func (t *TPS) ToIR() TPSIR {
 	return TPSIR{
-		CurrentTPS: t.CurrentTPS.FloatString(),
-		MaxTPS:     t.MaxTPS.FloatString(),
+		CurrentTPS: t.CurrentTPS.String(),
+		MaxTPS:     t.MaxTPS.String(),
 	}
 }
 
@@ -70,7 +70,7 @@ type ConsumptionMeta struct {
 // ToIR -
 func (c *ConsumptionMeta) ToIR() ConsumptionMetaIR {
 	return ConsumptionMetaIR{
-		ConsumptionFrictionRate:      c.ConsumptionFrictionRate.FloatString(),
+		ConsumptionFrictionRate:      c.ConsumptionFrictionRate.String(),
 		ConsumptionWindow:            c.ConsumptionWindow,
 		ConsumptionRewardPool:        c.ConsumptionRewardPool,
 		ConsumptionFreezingPeriodSec: c.ConsumptionFreezingPeriodSec,

--- a/x/global/model/ir.go
+++ b/x/global/model/ir.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// ConsumptionMetaIR - ConsumptionFrictionRate rat -> float string
+type ConsumptionMetaIR struct {
+	ConsumptionFrictionRate      string     `json:"consumption_friction_rate"`
+	ConsumptionWindow            types.Coin `json:"consumption_window"`
+	ConsumptionRewardPool        types.Coin `json:"consumption_reward_pool"`
+	ConsumptionFreezingPeriodSec int64      `json:"consumption_freezing_period_second"`
+}
+
+// TPSIR - all from rat to float string
+type TPSIR struct {
+	CurrentTPS string `json:"current_tps"`
+	MaxTPS     string `json:"max_tps"`
+}
+
+// GlobalMiscIR - ConsumptionMeta changed.
+type GlobalMiscIR struct {
+	Meta            GlobalMeta        `json:"meta"`
+	InflationPool   InflationPool     `json:"inflation_pool"`
+	ConsumptionMeta ConsumptionMetaIR `json:"consumption_meta"`
+	TPS             TPSIR             `json:"tps"`
+	Time            GlobalTime        `json:"time"`
+}
+
+// GlobalTablesIR - GlobalMisc changed.
+type GlobalTablesIR struct {
+	GlobalTimeEventLists []GlobalTimeEventTimeRow `json:"global_time_event_lists"`
+	GlobalStakeStats     []GlobalStakeStatDayRow  `json:"global_stake_stats"`
+	GlobalMisc           GlobalMiscIR             `json:"global_misc"`
+}

--- a/x/global/model/state.go
+++ b/x/global/model/state.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// GlobalTimeEventTimeRow - events, pk: UnixTime
+type GlobalTimeEventTimeRow struct {
+	UnixTime      int64               `json:"unix_time"`
+	TimeEventList types.TimeEventList `json:"time_event_list"`
+}
+
+// GlobalStakeStatDayRow - stake stats of a day, pk: day
+type GlobalStakeStatDayRow struct {
+	Day       int64         `json:"day"`
+	StakeStat LinoStakeStat `json:"stake_stat"`
+}
+
+// GlobalMisc - a bunch of global variables with no pk, pk: none
+type GlobalMisc struct {
+	Meta            GlobalMeta      `json:"meta"`
+	InflationPool   InflationPool   `json:"inflation_pool"`
+	ConsumptionMeta ConsumptionMeta `json:"consumption_meta"`
+	TPS             TPS             `json:"tps"`
+	Time            GlobalTime      `json:"time"`
+}
+
+// ToIR -
+func (g GlobalMisc) ToIR() GlobalMiscIR {
+	return GlobalMiscIR{
+		Meta:            g.Meta,
+		InflationPool:   g.InflationPool,
+		ConsumptionMeta: g.ConsumptionMeta.ToIR(),
+		TPS:             g.TPS.ToIR(),
+		Time:            g.Time,
+	}
+}
+
+// GlobalTables state of global.
+type GlobalTables struct {
+	GlobalTimeEventLists []GlobalTimeEventTimeRow `json:"global_time_event_lists"`
+	GlobalStakeStats     []GlobalStakeStatDayRow  `json:"global_stake_stats"`
+	GlobalMisc           GlobalMisc               `json:"global_misc"`
+}
+
+// ToIR -
+func (g GlobalTables) ToIR() GlobalTablesIR {
+	return GlobalTablesIR{
+		GlobalTimeEventLists: g.GlobalTimeEventLists,
+		GlobalStakeStats:     g.GlobalStakeStats,
+		GlobalMisc:           g.GlobalMisc.ToIR(),
+	}
+}

--- a/x/infra/manager.go
+++ b/x/infra/manager.go
@@ -147,4 +147,7 @@ func (im *InfraManager) ClearUsage(ctx sdk.Context) sdk.Error {
 	return nil
 }
 
-// ClearUsage - clear all infra provider report usage
+// Export state of infra.
+func (im *InfraManager) Export(ctx sdk.Context) *model.InfraTables {
+	return im.storage.Export(ctx)
+}

--- a/x/infra/model/ir.go
+++ b/x/infra/model/ir.go
@@ -1,0 +1,4 @@
+package model
+
+// InfraTablesIR - same
+type InfraTablesIR = InfraTables

--- a/x/infra/model/state.go
+++ b/x/infra/model/state.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// InfraProviderRow - infra provider, pk: app
+type InfraProviderRow struct {
+	App      types.AccountKey `json:"app"`
+	Provider InfraProvider    `json:"provider"`
+}
+
+// InfraProviderListRow - all providers, pk: none.
+type InfraProviderListRow struct {
+	List InfraProviderList `json:"list"`
+}
+
+// InfraTables infra storage state
+type InfraTables struct {
+	InfraProviders    []InfraProviderRow
+	InfraProviderList InfraProviderListRow
+}
+
+// ToIR - same
+func (i InfraTables) ToIR() InfraTablesIR {
+	return i
+}

--- a/x/post/manager.go
+++ b/x/post/manager.go
@@ -291,3 +291,8 @@ func (pm PostManager) GetPenaltyScore(ctx sdk.Context, reputation types.Coin) (s
 	}
 	return penaltyScore, nil
 }
+
+// Export - adaptor to storage Export.
+func (pm PostManager) Export(ctx sdk.Context) *model.PostTables {
+	return pm.postStorage.Export(ctx)
+}

--- a/x/post/model/ir.go
+++ b/x/post/model/ir.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// PostMetaIR RedistributionSplitRate rat -> string
+type PostMetaIR struct {
+	CreatedAt               int64      `json:"created_at"`
+	LastUpdatedAt           int64      `json:"last_updated_at"`
+	LastActivityAt          int64      `json:"last_activity_at"`
+	AllowReplies            bool       `json:"allow_replies"`
+	IsDeleted               bool       `json:"is_deleted"`
+	TotalDonateCount        int64      `json:"total_donate_count"`
+	TotalReportCoinDay      types.Coin `json:"total_report_coin_day"`
+	TotalUpvoteCoinDay      types.Coin `json:"total_upvote_coin_day"`
+	TotalViewCount          int64      `json:"total_view_count"`
+	TotalReward             types.Coin `json:"total_reward"`
+	RedistributionSplitRate string     `json:"redistribution_split_rate"`
+}
+
+// PostRowIR - Meta changed
+type PostRowIR struct {
+	Permlink types.Permlink `json:"permlink"`
+	Info     PostInfo       `json:"info"`
+	Meta     PostMetaIR     `json:"meta"`
+}
+
+// PostTablesIR - PostRow changed.
+type PostTablesIR struct {
+	Posts     []PostRowIR   `json:"posts"`
+	PostUsers []PostUserRow `json:"post_users"`
+}

--- a/x/post/model/post.go
+++ b/x/post/model/post.go
@@ -53,7 +53,7 @@ func (pm PostMeta) ToIR() PostMetaIR {
 		TotalUpvoteCoinDay:      pm.TotalUpvoteCoinDay,
 		TotalViewCount:          pm.TotalViewCount,
 		TotalReward:             pm.TotalReward,
-		RedistributionSplitRate: pm.RedistributionSplitRate.FloatString(),
+		RedistributionSplitRate: pm.RedistributionSplitRate.String(), // XXX(yumin): rat to dec
 	}
 }
 

--- a/x/post/model/post.go
+++ b/x/post/model/post.go
@@ -40,6 +40,23 @@ type PostMeta struct {
 	RedistributionSplitRate sdk.Dec    `json:"redistribution_split_rate"`
 }
 
+// ToIR -
+func (pm PostMeta) ToIR() PostMetaIR {
+	return PostMetaIR{
+		CreatedAt:               pm.CreatedAt,
+		LastUpdatedAt:           pm.LastUpdatedAt,
+		LastActivityAt:          pm.LastActivityAt,
+		AllowReplies:            pm.AllowReplies,
+		IsDeleted:               pm.IsDeleted,
+		TotalDonateCount:        pm.TotalDonateCount,
+		TotalReportCoinDay:      pm.TotalReportCoinDay,
+		TotalUpvoteCoinDay:      pm.TotalUpvoteCoinDay,
+		TotalViewCount:          pm.TotalViewCount,
+		TotalReward:             pm.TotalReward,
+		RedistributionSplitRate: pm.RedistributionSplitRate.FloatString(),
+	}
+}
+
 // ReportOrUpvote - report or upvote from a user to a post
 type ReportOrUpvote struct {
 	Username  types.AccountKey `json:"username"`

--- a/x/post/model/state.go
+++ b/x/post/model/state.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// PostRow - pk: permlink
+type PostRow struct {
+	Permlink types.Permlink `json:"permlink"`
+	Info     PostInfo       `json:"info"`
+	Meta     PostMeta       `json:"meta"`
+}
+
+// ToIR -
+func (p PostRow) ToIR() PostRowIR {
+	return PostRowIR{
+		Permlink: p.Permlink,
+		Info:     p.Info,
+		Meta:     p.Meta.ToIR(),
+	}
+}
+
+// PostUserRow - pk: (permlink, user)
+type PostUserRow struct {
+	Permlink       types.Permlink   `json:"permlink"`
+	User           types.AccountKey `json:"user"`
+	ReportOrUpvote ReportOrUpvote   `json:"report_or_upvote"`
+	// XXX(yumin): not exported for upgrade-1
+	// View           View             `json:"view"`
+	// Donations      Donations        `json:"donations"`
+}
+
+// XXX(yumin): not exported for upgrade-1
+// PostCommentRow - pk: (permlink, commentPermlink)
+// type PostCommentRow struct {
+// 	Permlink        types.Permlink `json:"permlink"`
+// 	CommentPermlink types.Permlink `json:"comment_permlink"`
+// 	Comment         Comment        `json:"comment"`
+// }
+
+// PostTables - state of post store.
+type PostTables struct {
+	Posts     []PostRow     `json:"posts"`
+	PostUsers []PostUserRow `json:"post_users"`
+	// not exported for upgrade-1
+	// PostComments []PostCommentRow `json:"post_comments"`
+}
+
+// ToIR -
+func (p PostTables) ToIR() *PostTablesIR {
+	rst := &PostTablesIR{}
+	for _, v := range p.Posts {
+		rst.Posts = append(rst.Posts, v.ToIR())
+	}
+	rst.PostUsers = p.PostUsers
+	return rst
+}

--- a/x/proposal/model/storage.go
+++ b/x/proposal/model/storage.go
@@ -207,6 +207,7 @@ func getNextProposalIDKey() []byte {
 	return nextProposalIDSubstore
 }
 
+// XXX(yumin): a overflow bug if end = 255
 func subspace(prefix []byte) (start, end []byte) {
 	end = make([]byte, len(prefix))
 	copy(end, prefix)

--- a/x/reputation/internal/encoder.go
+++ b/x/reputation/internal/encoder.go
@@ -1,10 +1,31 @@
 package internal
 
 import (
+	"errors"
+
 	wire "github.com/cosmos/cosmos-sdk/codec"
 )
 
 var cdc = wire.New()
+
+func encodeReputationStoreState(dt *reputationStoreState) ([]byte, error) {
+	if dt == nil {
+		return nil, errors.New("nil reputationStoreState")
+	}
+	return cdc.MarshalBinaryBare(dt)
+}
+
+func decodeReputationStoreState(data []byte) (*reputationStoreState, error) {
+	if data == nil {
+		return nil, errors.New("nil data in decodeReputationStoreState")
+	}
+	rst := &reputationStoreState{}
+	err := cdc.UnmarshalBinaryBare(data, rst)
+	if err != nil {
+		return nil, err
+	}
+	return rst, nil
+}
 
 // ------ following codes are generated from codegen/genGobCode.py --------
 // ------------------------- DO NOT CHANGE --------------------------------

--- a/x/reputation/internal/reputation.go
+++ b/x/reputation/internal/reputation.go
@@ -16,6 +16,10 @@ type Reputation interface {
 	GetReputation(u Uid) Rep
 	GetSumRep(p Pid) Rep
 	GetCurrentRound() (RoundId, Time) // current round and its start time.
+
+	// ExportImporter
+	Export() ([]byte, error)
+	Import(dt []byte) error
 }
 
 type ReputationImpl struct {
@@ -24,6 +28,16 @@ type ReputationImpl struct {
 
 func NewReputation(s ReputationStore) Reputation {
 	return &ReputationImpl{store: s}
+}
+
+// Export - implementing ExporteImporter
+func (rep ReputationImpl) Export() ([]byte, error) {
+	return rep.store.Export()
+}
+
+// Import - implementing ExporteImporter
+func (rep ReputationImpl) Import(dt []byte) error {
+	return rep.store.Import(dt)
 }
 
 func (rep ReputationImpl) GetReputation(u Uid) Rep {

--- a/x/reputation/internal/reputation_test.go
+++ b/x/reputation/internal/reputation_test.go
@@ -30,6 +30,19 @@ func (s *mockStore) Get(key []byte) []byte {
 	}
 }
 
+func (s *mockStore) Has(key []byte) bool {
+	_, ok := s.store[string(key)]
+	return ok
+}
+
+func (s *mockStore) Delete(key []byte) {
+	delete(s.store, string(key))
+}
+
+func (s *mockStore) Iterator(start, end []byte) Iterator {
+	panic("not implemented")
+}
+
 var _ Store = &mockStore{}
 
 func TestMockStore(t *testing.T) {

--- a/x/reputation/internal/utils.go
+++ b/x/reputation/internal/utils.go
@@ -1,0 +1,27 @@
+package internal
+
+// PrefixEndBytes returns the []byte that would end a
+// range query for all []byte with a certain prefix
+// Deals with last byte of prefix being FF without overflowing
+func PrefixEndBytes(prefix []byte) []byte {
+	if prefix == nil || len(prefix) == 0 {
+		return nil
+	}
+
+	end := make([]byte, len(prefix))
+	copy(end, prefix)
+
+	for {
+		if end[len(end)-1] != byte(255) {
+			end[len(end)-1]++
+			break
+		} else {
+			end = end[:len(end)-1]
+			if len(end) == 0 {
+				end = nil
+				break
+			}
+		}
+	}
+	return end
+}

--- a/x/validator/manager.go
+++ b/x/validator/manager.go
@@ -554,3 +554,8 @@ func (vm ValidatorManager) getBestCandidate(ctx sdk.Context) (types.AccountKey, 
 	return bestCandidate, nil
 
 }
+
+// Export storage state.
+func (vm ValidatorManager) Export(ctx sdk.Context) *model.ValidatorTables {
+	return vm.storage.Export(ctx)
+}

--- a/x/validator/model/ir.go
+++ b/x/validator/model/ir.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// ABCIPubKeyIR - type changed during upgrade.
+type ABCIPubKeyIR struct {
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	Data []byte `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+// ABCIValidatorIR - type changed during upgrade.
+type ABCIValidatorIR struct {
+	Address []byte       `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	PubKey  ABCIPubKeyIR `protobuf:"bytes,2,opt,name=pub_key,json=pubKey" json:"pub_key"`
+	Power   int64        `protobuf:"varint,3,opt,name=power,proto3" json:"power,omitempty"`
+}
+
+// ValidatorIR - ABCIValidator internally changed.
+type ValidatorIR struct {
+	ABCIValidator   ABCIValidatorIR
+	Username        types.AccountKey `json:"username"`
+	Deposit         types.Coin       `json:"deposit"`
+	AbsentCommit    int64            `json:"absent_commit"`
+	ByzantineCommit int64            `json:"byzantine_commit"`
+	ProducedBlocks  int64            `json:"produced_blocks"`
+	Link            string           `json:"link"`
+}
+
+// ValidatorRowIR - pk: (Username)
+type ValidatorRowIR struct {
+	Username types.AccountKey `json:"username"`
+	// XXX(yumin): type changed.
+	Validator ValidatorIR `json:"validator"`
+}
+
+// ValidatorTablesIR - Validators changed.
+type ValidatorTablesIR struct {
+	Validators    []ValidatorRowIR `json:"validators"`
+	ValidatorList ValidatorListRow `json:"validator_list"`
+}

--- a/x/validator/model/state.go
+++ b/x/validator/model/state.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/lino-network/lino/types"
+)
+
+// ValidatorRow - pk: (Username)
+type ValidatorRow struct {
+	Username types.AccountKey `json:"username"`
+	// XXX(yumin): type changed.
+	Validator Validator `json:"validator"`
+}
+
+// ToIR -
+func (v ValidatorRow) ToIR() ValidatorRowIR {
+	return ValidatorRowIR{
+		Username:  v.Username,
+		Validator: v.Validator.ToIR(),
+	}
+}
+
+// ValidatorListRow - pk: none
+type ValidatorListRow struct {
+	List ValidatorList `json:"list"`
+}
+
+// ValidatorTables state of validators
+type ValidatorTables struct {
+	Validators    []ValidatorRow   `json:"validators"`
+	ValidatorList ValidatorListRow `json:"validator_list"`
+}
+
+// ToIR -
+func (v ValidatorTables) ToIR() *ValidatorTablesIR {
+	rst := &ValidatorTablesIR{}
+	for _, v := range v.Validators {
+		rst.Validators = append(rst.Validators, v.ToIR())
+	}
+	rst.ValidatorList = v.ValidatorList
+	return rst
+}

--- a/x/validator/model/validator.go
+++ b/x/validator/model/validator.go
@@ -3,6 +3,7 @@ package model
 import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	types "github.com/lino-network/lino/types"
 )
@@ -21,12 +22,13 @@ type Validator struct {
 
 // ToIR -
 func (v Validator) ToIR() ValidatorIR {
+	abciPubKey := tmtypes.TM2PB.PubKey(v.PubKey)
 	return ValidatorIR{
 		ABCIValidator: ABCIValidatorIR{
 			Address: v.ABCIValidator.Address,
 			PubKey: ABCIPubKeyIR{
-				Type: v.ABCIValidator.PubKey.Type,
-				Data: v.ABCIValidator.PubKey.Data,
+				Type: abciPubKey.Type,
+				Data: abciPubKey.Data,
 			},
 			Power: v.ABCIValidator.Power,
 		},

--- a/x/validator/model/validator.go
+++ b/x/validator/model/validator.go
@@ -19,7 +19,27 @@ type Validator struct {
 	Link            string           `json:"link"`
 }
 
-// Validator list
+// ToIR -
+func (v Validator) ToIR() ValidatorIR {
+	return ValidatorIR{
+		ABCIValidator: ABCIValidatorIR{
+			Address: v.ABCIValidator.Address,
+			PubKey: ABCIPubKeyIR{
+				Type: v.ABCIValidator.PubKey.Type,
+				Data: v.ABCIValidator.PubKey.Data,
+			},
+			Power: v.ABCIValidator.Power,
+		},
+		Username:        v.Username,
+		Deposit:         v.Deposit,
+		AbsentCommit:    v.AbsentCommit,
+		ByzantineCommit: v.ByzantineCommit,
+		ProducedBlocks:  v.ProducedBlocks,
+		Link:            v.Link,
+	}
+}
+
+// ValidatorList -
 type ValidatorList struct {
 	OncallValidators   []types.AccountKey `json:"oncall_validators"`
 	AllValidators      []types.AccountKey `json:"all_validators"`


### PR DESCRIPTION
This PR introduce app state IR and app state exporter to the new version, which is the requirement for introducing app state importer. Codes are migrated from the old version, with updating some type discrepancies.