### PR TITLE
Change reputation exportimporter: only export scores

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -727,13 +727,7 @@ func (lb *LinoBlockchain) ExportAppStateAndValidators() (appState json.RawMessag
 	exportToFile(voterStateFile, func(ctx sdk.Context) interface{} {
 		return lb.voteManager.Export(ctx).ToIR()
 	})
-	exportToFile(reputationStateFile, func(ctx sdk.Context) interface{} {
-		rep, err := lb.reputationManager.Export(ctx)
-		if err != nil {
-			panic(err)
-		}
-		return rep
-	})
+	lb.reputationManager.ExportToFile(ctx, exportPath + "reputation")
 
 	genesisState := GenesisState{}
 
@@ -797,11 +791,8 @@ func (lb *LinoBlockchain) ImportFromFiles(ctx sdk.Context) {
 			check(err)
 			fmt.Printf("%s state parsed: %T\n", filename, t)
 			lb.voteManager.Import(ctx, t)
-		case *[]byte:
-			err = lb.cdc.UnmarshalJSON(bytes, t)
-			check(err)
-			fmt.Printf("%s state parsed: %T\n", filename, t)
-			lb.reputationManager.Import(ctx, *t)
+		default:
+			panic(fmt.Sprintf("Unknown import type: %T", t))
 		}
 		fmt.Printf("%s loaded, total %d bytes\n", filename, len(bytes))
 	}
@@ -812,6 +803,6 @@ func (lb *LinoBlockchain) ImportFromFiles(ctx sdk.Context) {
 	importFromFile(globalStateFile, &globalmodel.GlobalTablesIR{})
 	importFromFile(infraStateFile, &inframodel.InfraTablesIR{})
 	importFromFile(validatorStateFile, &valmodel.ValidatorTablesIR{})
-	importFromFile(reputationStateFile, &[]byte{})
 	importFromFile(voterStateFile, &votemodel.VoterTablesIR{})
+	lb.reputationManager.ImportFromFile(ctx, DefaultNodeHome + "/" + prevStateFolder + reputationStateFile)
 }

--- a/x/reputation/internal/codegen/genGobCode.py
+++ b/x/reputation/internal/codegen/genGobCode.py
@@ -11,7 +11,7 @@ func decode$TYPE(data []byte) *TYPE {
 		return nil
 	}
 	rst := &TYPE{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode TYPE" + err.Error())
 	}
@@ -22,7 +22,7 @@ func encode$TYPE(dt *TYPE) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}

--- a/x/reputation/internal/encoder.go
+++ b/x/reputation/internal/encoder.go
@@ -1,31 +1,10 @@
 package internal
 
 import (
-	"errors"
-
 	wire "github.com/cosmos/cosmos-sdk/codec"
 )
 
 var cdc = wire.New()
-
-func encodeReputationStoreState(dt *reputationStoreState) ([]byte, error) {
-	if dt == nil {
-		return nil, errors.New("nil reputationStoreState")
-	}
-	return cdc.MarshalBinaryLengthPrefixed(dt)
-}
-
-func decodeReputationStoreState(data []byte) (*reputationStoreState, error) {
-	if data == nil {
-		return nil, errors.New("nil data in decodeReputationStoreState")
-	}
-	rst := &reputationStoreState{}
-	err := cdc.UnmarshalBinaryLengthPrefixed(data, rst)
-	if err != nil {
-		return nil, err
-	}
-	return rst, nil
-}
 
 // ------ following codes are generated from codegen/genGobCode.py --------
 // ------------------------- DO NOT CHANGE --------------------------------
@@ -34,7 +13,7 @@ func decodeUserMeta(data []byte) *userMeta {
 		return nil
 	}
 	rst := &userMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode userMeta" + err.Error())
 	}
@@ -45,7 +24,7 @@ func encodeUserMeta(dt *userMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -57,7 +36,7 @@ func decodePostMeta(data []byte) *postMeta {
 		return nil
 	}
 	rst := &postMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode postMeta" + err.Error())
 	}
@@ -68,7 +47,7 @@ func encodePostMeta(dt *postMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -80,7 +59,7 @@ func decodeRoundMeta(data []byte) *roundMeta {
 		return nil
 	}
 	rst := &roundMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode roundMeta" + err.Error())
 	}
@@ -91,7 +70,7 @@ func encodeRoundMeta(dt *roundMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -103,7 +82,7 @@ func decodeUserPostMeta(data []byte) *userPostMeta {
 		return nil
 	}
 	rst := &userPostMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode userPostMeta" + err.Error())
 	}
@@ -114,7 +93,7 @@ func encodeUserPostMeta(dt *userPostMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -126,7 +105,7 @@ func decodeRoundPostMeta(data []byte) *roundPostMeta {
 		return nil
 	}
 	rst := &roundPostMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode roundPostMeta" + err.Error())
 	}
@@ -137,7 +116,7 @@ func encodeRoundPostMeta(dt *roundPostMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -149,7 +128,7 @@ func decodeRoundUserPostMeta(data []byte) *roundUserPostMeta {
 		return nil
 	}
 	rst := &roundUserPostMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode roundUserPostMeta" + err.Error())
 	}
@@ -160,7 +139,7 @@ func encodeRoundUserPostMeta(dt *roundUserPostMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}
@@ -172,7 +151,7 @@ func decodeGameMeta(data []byte) *gameMeta {
 		return nil
 	}
 	rst := &gameMeta{}
-	err := cdc.UnmarshalJSON(data, rst)
+	err := cdc.UnmarshalBinaryBare(data, rst)
 	if err != nil {
 		panic("error in json decode gameMeta" + err.Error())
 	}
@@ -183,7 +162,7 @@ func encodeGameMeta(dt *gameMeta) []byte {
 	if dt == nil {
 		return nil
 	}
-	rst, err := cdc.MarshalJSON(dt)
+	rst, err := cdc.MarshalBinaryBare(dt)
 	if err != nil {
 		panic("error in encoding: " + err.Error())
 	}

--- a/x/reputation/internal/reputation.go
+++ b/x/reputation/internal/reputation.go
@@ -18,8 +18,8 @@ type Reputation interface {
 	GetCurrentRound() (RoundId, Time) // current round and its start time.
 
 	// ExportImporter
-	Export() ([]byte, error)
-	Import(dt []byte) error
+	ExportToFile(file string)
+	ImportFromFile(file string)
 }
 
 type ReputationImpl struct {
@@ -30,15 +30,20 @@ func NewReputation(s ReputationStore) Reputation {
 	return &ReputationImpl{store: s}
 }
 
-// Export - implementing ExporteImporter
-func (rep ReputationImpl) Export() ([]byte, error) {
-	return rep.store.Export()
+// ExportToFile - implementing ExporteImporter
+func (rep ReputationImpl) ExportToFile(f string) {
+	rep.store.ExportToFile(f)
+}
+
+// ImportFromFile - implementing ExporteImporter
+func (rep ReputationImpl) ImportFromFile(f string) {
+	rep.store.ImportFromFile(f)
 }
 
 // Import - implementing ExporteImporter
-func (rep ReputationImpl) Import(dt []byte) error {
-	return rep.store.Import(dt)
-}
+// func (rep ReputationImpl) Import(dt []byte) error {
+// 	rep.store.Import(dt)
+// }
 
 func (rep ReputationImpl) GetReputation(u Uid) Rep {
 	customerScore := rep.GetSettledCustomerScore(u)

--- a/x/reputation/internal/state.go
+++ b/x/reputation/internal/state.go
@@ -2,12 +2,12 @@ package internal
 
 // UserReputation - pk: Username
 type UserReputation struct {
-	Username          Uid
-	CustomerScore     Rep
-	FreeScore         Rep
+	Username      Uid `json:"username"`
+	CustomerScore Rep `json:"customer_score"`
+	FreeScore     Rep `json:"free_score"`
 }
 
 // UserReputationTable -
 type UserReputationTable struct {
-	reputations []UserReputation
+	Reputations []UserReputation `json:"reputations"`
 }

--- a/x/reputation/internal/state.go
+++ b/x/reputation/internal/state.go
@@ -1,0 +1,13 @@
+package internal
+
+// UserReputation - pk: Username
+type UserReputation struct {
+	Username          Uid
+	CustomerScore     Rep
+	FreeScore         Rep
+}
+
+// UserReputationTable -
+type UserReputationTable struct {
+	reputations []UserReputation
+}

--- a/x/reputation/internal/store.go
+++ b/x/reputation/internal/store.go
@@ -9,6 +9,9 @@ import (
 	"encoding/binary"
 	"math/big"
 	"sort"
+	"os"
+	"strings"
+	"io/ioutil"
 )
 
 // Store - store.
@@ -34,9 +37,12 @@ type ReputationStore interface {
 	// TODO(yumin): these two are all in memory, which is extremely bad if state is large.
 	// should changed to io.Write/Reader.
 	// Export all state to deterministic bytes
-	Export() ([]byte, error)
+	Export() *UserReputationTable
+	ExportToFile(file string)
+
 	// Import state from bytes
-	Import(bytes []byte) error
+	Import(tb *UserReputationTable)
+	ImportFromFile(file string)
 
 	// Note that, this value may not be the exact customer score of the user
 	// due to there might be unsettled keys remaining.
@@ -228,35 +234,66 @@ func NewReputationStore(s Store, n int) ReputationStore {
 	return &reputationStoreImpl{store: s, BestContentIndexN: n}
 }
 
-type repKV struct {
-	Key   []byte
-	Value []byte
-}
-
-type reputationStoreState struct {
-	KVs []repKV `json:"kvs"`
-}
-
-func (impl reputationStoreImpl) Export() ([]byte, error) {
-	rst := reputationStoreState{}
-	itr := impl.store.Iterator(nil, nil)
+func (impl reputationStoreImpl) Export() *UserReputationTable {
+	rst := &UserReputationTable{}
+	itr := impl.store.Iterator(repUserMetaPrefix, PrefixEndBytes(repUserMetaPrefix))
 	defer itr.Close()
-	for itr.Valid() {
-		rst.KVs = append(rst.KVs, repKV{Key: itr.Key(), Value: itr.Value()})
-		itr.Next()
+	for ; itr.Valid(); itr.Next() {
+		uid := Uid(itr.Key()[1:])
+		if strings.Contains(uid, string(KeySeparator)) {
+			continue
+		}
+		v := impl.getUserMeta(uid)
+		rst.reputations = append(rst.reputations, UserReputation{
+			Username: uid,
+			CustomerScore: v.CustomerScore,
+			FreeScore: v.FreeScore,
+		})
 	}
-	return encodeReputationStoreState(&rst)
+	return rst
 }
 
-func (impl reputationStoreImpl) Import(bytes []byte) error {
-	state, err := decodeReputationStoreState(bytes)
+func (impl reputationStoreImpl) ExportToFile(file string) {
+	rst := impl.Export()
+	f, err := os.Create(file)
 	if err != nil {
-		return err
+		panic("failed to create account")
 	}
-	for _, v := range state.KVs {
-		impl.store.Set(v.Key, v.Value)
+	defer f.Close()
+	jsonbytes, err := cdc.MarshalJSON(rst)
+	f.Write(jsonbytes)
+	if err != nil {
+		panic("failed to marshal json for " + file + " due to " + err.Error())
 	}
-	return nil
+	f.Sync()
+}
+
+
+func (impl reputationStoreImpl) Import(tb *UserReputationTable) {
+	for _, v := range tb.reputations {
+		impl.setUserMeta(v.Username, &userMeta{
+			FreeScore: v.FreeScore,
+			CustomerScore: v.CustomerScore,
+		})
+	}
+}
+
+func (impl reputationStoreImpl) ImportFromFile(file string) {
+	f, err := os.Open(file)
+	if err != nil {
+		panic("failed to open " + err.Error())
+	}
+	defer f.Close()
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		panic("failed to readall: " + err.Error())
+	}
+	dt := &UserReputationTable{}
+	err = cdc.UnmarshalJSON(bytes, dt)
+	if err != nil {
+		panic("failed to unmarshal: " + err.Error())
+	}
+	impl.Import(dt)
 }
 
 // TODO(yumin): a cache can help to make it faster.

--- a/x/reputation/internal/store.go
+++ b/x/reputation/internal/store.go
@@ -244,7 +244,7 @@ func (impl reputationStoreImpl) Export() *UserReputationTable {
 			continue
 		}
 		v := impl.getUserMeta(uid)
-		rst.reputations = append(rst.reputations, UserReputation{
+		rst.Reputations = append(rst.Reputations, UserReputation{
 			Username: uid,
 			CustomerScore: v.CustomerScore,
 			FreeScore: v.FreeScore,
@@ -261,16 +261,16 @@ func (impl reputationStoreImpl) ExportToFile(file string) {
 	}
 	defer f.Close()
 	jsonbytes, err := cdc.MarshalJSON(rst)
-	f.Write(jsonbytes)
 	if err != nil {
 		panic("failed to marshal json for " + file + " due to " + err.Error())
 	}
+	f.Write(jsonbytes)
 	f.Sync()
 }
 
 
 func (impl reputationStoreImpl) Import(tb *UserReputationTable) {
-	for _, v := range tb.reputations {
+	for _, v := range tb.Reputations {
 		impl.setUserMeta(v.Username, &userMeta{
 			FreeScore: v.FreeScore,
 			CustomerScore: v.CustomerScore,

--- a/x/reputation/manager.go
+++ b/x/reputation/manager.go
@@ -190,20 +190,22 @@ func (rep ReputationManager) GetCurrentRound(ctx sdk.Context) (int64, sdk.Error)
 	return ts, nil
 }
 
-// Import reputation system.
-func (rep ReputationManager) Import(ctx sdk.Context, dt []byte) error {
+// ExportToFile state of reputation system.
+func (rep ReputationManager) ExportToFile(ctx sdk.Context, file string) error {
 	handler, err := rep.getHandler(ctx)
 	if err != nil {
 		return err
 	}
-	return handler.Import(dt)
+	handler.ExportToFile(file)
+	return nil
 }
 
-// Export state of reputation system.
-func (rep ReputationManager) Export(ctx sdk.Context) ([]byte, error) {
+// ImportFromFile state of reputation system.
+func (rep ReputationManager) ImportFromFile(ctx sdk.Context, file string) error {
 	handler, err := rep.getHandler(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return handler.Export()
+	handler.ImportFromFile(file)
+	return nil
 }


### PR DESCRIPTION
We have created a lot of key-value pairs in reputation, most of them are not usefully to be migrated.