### PR TITLE
Fix cached tx indexer

### DIFF
--- a/patches/fullnode/tendermint-cached-txindexer.patch
+++ b/patches/fullnode/tendermint-cached-txindexer.patch
@@ -154,7 +154,7 @@ index ab509f96..c8aee640 100644
  	// AddBatch analyzes, indexes and stores a batch of transactions.
  	AddBatch(b *Batch) error
 diff --git a/state/txindex/kv/kv.go b/state/txindex/kv/kv.go
-index 93249b7f..2195ec2c 100644
+index 93249b7f..defadfbb 100644
 --- a/state/txindex/kv/kv.go
 +++ b/state/txindex/kv/kv.go
 @@ -7,11 +7,13 @@ import (
@@ -197,7 +197,7 @@ index 93249b7f..2195ec2c 100644
  	for _, o := range options {
  		o(txi)
  	}
-@@ -54,6 +62,36 @@ func IndexAllTags() func(*TxIndex) {
+@@ -54,6 +62,39 @@ func IndexAllTags() func(*TxIndex) {
  	}
  }
  
@@ -211,6 +211,9 @@ index 93249b7f..2195ec2c 100644
 +func (txi *TxIndex) removeFromCache(hash []byte) {
 +	txi.cacheMux.Lock()
 +	defer txi.cacheMux.Unlock()
++	if _, ok := txi.cache[string(hash)]; !ok {
++		txi.logger.Error("[CachedTxIndexer] Removing non-existed hash")
++	}
 +	delete(txi.cache, string(hash))
 +}
 +
@@ -234,7 +237,7 @@ index 93249b7f..2195ec2c 100644
  // Get gets transaction from the TxIndex storage and returns it or nil if the
  // transaction is not found.
  func (txi *TxIndex) Get(hash []byte) (*types.TxResult, error) {
-@@ -61,6 +99,10 @@ func (txi *TxIndex) Get(hash []byte) (*types.TxResult, error) {
+@@ -61,6 +102,10 @@ func (txi *TxIndex) Get(hash []byte) (*types.TxResult, error) {
  		return nil, txindex.ErrorEmptyHash
  	}
  
@@ -245,7 +248,7 @@ index 93249b7f..2195ec2c 100644
  	rawBytes := txi.store.Get(hash)
  	if rawBytes == nil {
  		return nil, nil
-@@ -103,6 +145,12 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
+@@ -103,6 +148,12 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
  	}
  
  	storeBatch.Write()

--- a/patches/fullnode/tendermint-cached-txindexer.patch
+++ b/patches/fullnode/tendermint-cached-txindexer.patch
@@ -1,15 +1,56 @@
 diff --git a/consensus/replay.go b/consensus/replay.go
-index 21fef6b2..1426cfe7 100644
+index 21fef6b2..e2593496 100644
 --- a/consensus/replay.go
 +++ b/consensus/replay.go
-@@ -441,6 +441,7 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
- 	meta := h.store.LoadBlockMeta(height)
+@@ -16,6 +16,8 @@ import (
+ 	cmn "github.com/tendermint/tendermint/libs/common"
+ 	dbm "github.com/tendermint/tendermint/libs/db"
+ 	"github.com/tendermint/tendermint/libs/log"
++	"github.com/tendermint/tendermint/state/txindex"
++	nulltxindexer "github.com/tendermint/tendermint/state/txindex/null"
  
+ 	"github.com/tendermint/tendermint/proxy"
+ 	sm "github.com/tendermint/tendermint/state"
+@@ -201,6 +203,9 @@ type Handshaker struct {
+ 	genDoc       *types.GenesisDoc
+ 	logger       log.Logger
+ 
++	// indexer, null cacher if not set
++	txindexer txindex.TxIndexer
++
+ 	nBlocks int // number of blocks applied to the state
+ }
+ 
+@@ -214,6 +219,7 @@ func NewHandshaker(stateDB dbm.DB, state sm.State,
+ 		eventBus:     types.NopEventBus{},
+ 		genDoc:       genDoc,
+ 		logger:       log.NewNopLogger(),
++		txindexer:    &nulltxindexer.TxIndex{},
+ 		nBlocks:      0,
+ 	}
+ }
+@@ -222,6 +228,11 @@ func (h *Handshaker) SetLogger(l log.Logger) {
+ 	h.logger = l
+ }
+ 
++// SetTxIndexer - sets tx indexer, if not called, nulltxinders.
++func (h *Handshaker) SetTxIndexer(indexer txindex.TxIndexer) {
++	h.txindexer = indexer
++}
++
+ // SetEventBus - sets the event bus for publishing block related events.
+ // If not called, it defaults to types.NopEventBus.
+ func (h *Handshaker) SetEventBus(eventBus types.BlockEventPublisher) {
+@@ -443,6 +454,9 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
  	blockExec := sm.NewBlockExecutor(h.stateDB, h.logger, proxyApp, sm.MockMempool{}, sm.MockEvidencePool{})
-+	// XXX(yumin): setTxIndexer for cache is skipped.
  	blockExec.SetEventBus(h.eventBus)
  
++	// XXX(yumin): setTxIndexer for cache is required as fullnodes hit this path.
++	blockExec.SetTxIndexer(h.txindexer)
++
  	var err error
+ 	state, err = blockExec.ApplyBlock(state, meta.BlockID, block)
+ 	if err != nil {
 diff --git a/node/node.go b/node/node.go
 index 969452c4..c86efcf1 100644
 --- a/node/node.go
@@ -25,7 +66,7 @@ index 969452c4..c86efcf1 100644
  	bcReactor := bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
  	bcReactor.SetLogger(logger.With("module", "blockchain"))
 diff --git a/state/execution.go b/state/execution.go
-index 8ab95839..76748f79 100644
+index 8ab95839..3637e1d7 100644
 --- a/state/execution.go
 +++ b/state/execution.go
 @@ -9,6 +9,8 @@ import (
@@ -73,7 +114,7 @@ index 8ab95839..76748f79 100644
  	return res
  }
  
-+// SetTxIndexer - sets tx indexer, if not called, nil, so
++// SetTxIndexer - sets tx indexer, if not called, nulltxinders.
 +func (blockExec *BlockExecutor) SetTxIndexer(indexer txindex.TxIndexer) {
 +	blockExec.txindexer = indexer
 +}

--- a/patches/fullnode/tendermint-cached-txindexer.patch
+++ b/patches/fullnode/tendermint-cached-txindexer.patch
@@ -66,7 +66,7 @@ index 969452c4..c86efcf1 100644
  	bcReactor := bc.NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
  	bcReactor.SetLogger(logger.With("module", "blockchain"))
 diff --git a/state/execution.go b/state/execution.go
-index 8ab95839..3637e1d7 100644
+index 8ab95839..cca5c1a9 100644
 --- a/state/execution.go
 +++ b/state/execution.go
 @@ -9,6 +9,8 @@ import (
@@ -122,12 +122,11 @@ index 8ab95839..3637e1d7 100644
  // SetEventBus - sets the event bus for publishing block related events.
  // If not called, it defaults to types.NopEventBus.
  func (blockExec *BlockExecutor) SetEventBus(eventBus types.BlockEventPublisher) {
-@@ -161,6 +172,17 @@ func (blockExec *BlockExecutor) ApplyBlock(state State, blockID types.BlockID, b
+@@ -150,6 +161,16 @@ func (blockExec *BlockExecutor) ApplyBlock(state State, blockID types.BlockID, b
+ 		return state, fmt.Errorf("Commit failed for application: %v", err)
+ 	}
  
- 	fail.Fail() // XXX
- 
-+	// XXX(yumin): this must happens before SaveState.
-+	// cache txs
++	// XXX(yumin): this must happen before Commit to cache txs.
 +	for i, tx := range block.Data.Txs {
 +		blockExec.txindexer.Cache(&types.TxResult{
 +			Height: block.Height,
@@ -137,9 +136,9 @@ index 8ab95839..3637e1d7 100644
 +		})
 +	}
 +
- 	// Update the app hash and save the state.
- 	state.AppHash = appHash
- 	SaveState(blockExec.db, state)
+ 	// Lock mempool, commit app state, update mempoool.
+ 	appHash, err := blockExec.Commit(state, block)
+ 	if err != nil {
 diff --git a/state/txindex/indexer.go b/state/txindex/indexer.go
 index ab509f96..c8aee640 100644
 --- a/state/txindex/indexer.go


### PR DESCRIPTION
1. in replay last block, cached tx indexer is applied as well.
2. cache should happen before Commit.